### PR TITLE
data_validation was not stopping

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -38,7 +38,6 @@ data_validation <- function(tab, list_pop_param, cov_continuous, cov_factors) {
       errors <- c(errors, error_message)
     }
   }
-  return(errors)
   
   if (length(errors) > 0) {
     stop(paste0(errors, sep = "\n"), call. = FALSE)


### PR DESCRIPTION
Data validation was not actually stopping the function when errors were found. Removed the return(errors) which was exiting the function early, and producing a non-useful error message downstream. 