### PR TITLE
Covariate requirement validation

### DIFF
--- a/R/generate_residuals_plot.R
+++ b/R/generate_residuals_plot.R
@@ -50,8 +50,8 @@ generate_residuals_plot <- function(data, result, pop_param, seed = 123) {
   result_5folds <- result$result_5folds
   
   # Check that covariates supplied by user exist in the data
-  data_validation(data, pop_params, cov_continuous, cov_factors)
-  
+  data_validation(data, pop_param, cov_continuous, cov_factors)
+
   # Select columns and generate data for XGBoost
   dat <- col_select(data, pop_params, cov_continuous, cov_factors)
   pop_params <- dat %>% dplyr::select(dplyr::all_of(pop_params))

--- a/R/ml_cov_search.R
+++ b/R/ml_cov_search.R
@@ -46,6 +46,19 @@
 #'
 ml_cov_search <- function(data, pop_param, cov_continuous, cov_factors, seed = 123) {
   
+  if (missing(cov_continuous) &&
+      missing(cov_factors)) {
+    stop(
+      "No covariates specified. Use `cov_continuous` and/or `cov_factors` argument to specify covariates to include in `ml_cov_search()`."
+    )
+  }
+  if (missing(cov_continuous)) {
+    cov_continuous <- NULL
+  }
+  if (missing(cov_factors)) {
+    cov_factors <- NULL
+  }
+  
   # Check that covariates supplied by user exist in the data
   data_validation(data, pop_param, cov_continuous, cov_factors)
 


### PR DESCRIPTION
To permit usage of missing `cov_factors`, or missing `cov_continuous` arguments in `ml_cov_search()`. If both are missing, return error.